### PR TITLE
chore: remove useless await statements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,7 @@ async function sendETH(ethWallet: ethers.Wallet, to: string, amount: BigNumber) 
         if (!TESTNET_PAYMASTER_ADDRESS) {
             console.log('Skipping step 1 -- send ETH to paymaster');
         } else {
-            [transferAmount, l2feeAccountBalance] = await calculateTransferAmount(
+            [transferAmount, l2feeAccountBalance] = calculateTransferAmount(
                 l2feeAccountBalance,
                 paymasterL2Balance,
                 UPPER_BOUND_PAYMASTER_THRESHOLD,
@@ -251,7 +251,7 @@ async function sendETH(ethWallet: ethers.Wallet, to: string, amount: BigNumber) 
         if (!WATCHDOG_ADDRESS) {
             console.log('Skipping step 2 -- send ETH to era-watchdog');
         } else {
-            [transferAmount, l2feeAccountBalance] = await calculateTransferAmount(
+            [transferAmount, l2feeAccountBalance] = calculateTransferAmount(
                 l2feeAccountBalance,
                 watchdogBalance,
                 UPPER_BOUND_WATCHDOG_THRESHOLD,
@@ -281,7 +281,7 @@ async function sendETH(ethWallet: ethers.Wallet, to: string, amount: BigNumber) 
         console.log(`----------------------------------------------------------------------------`);
 
         // calculate amounts for top ups on L1
-        [transferAmount, l1feeAccountBalance] = await calculateTransferAmount(
+        [transferAmount, l1feeAccountBalance] = calculateTransferAmount(
             l1feeAccountBalance,
             operatorBalance,
             UPPER_BOUND_OPERATOR_THRESHOLD,
@@ -298,7 +298,7 @@ async function sendETH(ethWallet: ethers.Wallet, to: string, amount: BigNumber) 
 
         console.log(`----------------------------------------------------------------------------`);
 
-        [transferAmount, l1feeAccountBalance] = await calculateTransferAmount(
+        [transferAmount, l1feeAccountBalance] = calculateTransferAmount(
             l1feeAccountBalance,
             blobOperatorBalance,
             UPPER_BOUND_BLOB_OPERATOR_THRESHOLD,
@@ -315,7 +315,7 @@ async function sendETH(ethWallet: ethers.Wallet, to: string, amount: BigNumber) 
 
         console.log(`----------------------------------------------------------------------------`);
 
-        [transferAmount, l1feeAccountBalance] = await calculateTransferAmount(
+        [transferAmount, l1feeAccountBalance] = calculateTransferAmount(
             l1feeAccountBalance,
             withdrawerBalance,
             UPPER_BOUND_WITHDRAWER_THRESHOLD,


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Removes useless `await` statements.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

The [calculateTransferAmount](https://github.com/matter-labs/era-fee-withdrawer/blob/586ce3e0063b438a3f1f7302b0d894bb52917fbf/src/transfer-calculator.ts#L4) function is not asynchronous, so using await has no effect. These changes improve code readability.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
